### PR TITLE
Fix register and show user avatar

### DIFF
--- a/src/components/layout/profile-menu.js
+++ b/src/components/layout/profile-menu.js
@@ -29,7 +29,11 @@ export const ProfileMenu = () => {
   return (
     <Menu>
       <MenuButton>
-        <Avatar boxSize={{ base: 10, lg: 12 }} rounded='lg' name={user.username}></Avatar>
+        <Avatar
+          boxSize={{ base: 10, lg: 12 }}
+          src={`${process.env.NEXT_PUBLIC_API_URL}${user.avatar?.formats.thumbnail.url || user.avatar?.url}`}
+          name={user.username}
+        />
       </MenuButton>
       <MenuList>
         <MenuItem>{user.username}</MenuItem>

--- a/src/pages/api/auth/login.js
+++ b/src/pages/api/auth/login.js
@@ -1,23 +1,32 @@
+import axios from 'axios'
 import { withIronSessionApiRoute } from 'iron-session/next'
 
-import { fetcher, sessionOptions } from '~lib'
+import { sessionOptions } from '~lib'
 
 const loginRoute = async (req, res) => {
   const { identifier, password } = req.body
 
   try {
-    const response = await fetcher.post(`api/auth/local`, {
+    const response = await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/api/auth/local`, {
       identifier,
       password,
     })
 
-    const user = { user: response.data.user, isLoggedIn: true, token: response.data.jwt }
+    const token = response.data.jwt
 
-    req.session = user
-    await req.session.save()
-    res.json(user)
+    if (token) {
+      const response = await axios.get(`${process.env.NEXT_PUBLIC_API_URL}/api/users/me?populate=*`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+
+      const auth = { user: response.data, token, isLoggedIn: true }
+
+      req.session = auth
+      await req.session.save()
+      res.json(auth)
+    }
   } catch (error) {
-    console.log('error', error)
+    console.log('error', error.response?.data)
     if (!error.response?.data?.error.message) {
       return res.status(500).json({ message: 'Internal server error' })
     } else {

--- a/src/pages/api/auth/user.js
+++ b/src/pages/api/auth/user.js
@@ -8,8 +8,7 @@ async function userRoute(req, res) {
     // and then do a database request
     // to get more information on the user if needed
     res.json({
-      user: req.session.user,
-      token: req.session.token,
+      ...req.session,
       isLoggedIn: true,
     })
   } else {

--- a/src/pages/profile/index.js
+++ b/src/pages/profile/index.js
@@ -6,7 +6,6 @@ import { Container, Layout } from '~components'
 import { sessionOptions } from '~lib'
 
 const Profile = ({ user }) => {
-  console.log('User', user)
   return (
     <Layout>
       <Container>

--- a/src/utils/truncate-text.js
+++ b/src/utils/truncate-text.js
@@ -1,4 +1,6 @@
 export const truncateText = (text, maxLen) => {
+  if (!text || typeof text !== 'string') return ''
+
   //trim the string to the maximum length
   const str = text.substr(0, maxLen)
 


### PR DESCRIPTION
Strapi doesn't populate user data because of some security concerns. There are still some open issues and pull requests about this. In order to have extended user data, in the backend I customized `api/users/me`, `api/users` and `api/users/:id` controllers  to populate user data according to provided populate query.

The process is basically:

1. User logs in or registers
2. Token received
3. Fetch `api/users/me?populate="*"`
4. Save the extended user data in `req.session`